### PR TITLE
Add Aerodrome LP provider support alongside Uniswap V3

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,7 @@
 # App
 PORT=3000
 WALLET_ADDRESS=0xYourWalletAddress
+LP_PROVIDER=uniswap  # Options: uniswap or aerodrome
 
 # Ethereum
 ETH_RPC_URL=https://mainnet.infura.io/v3/YOUR-PROJECT-ID
@@ -10,6 +11,12 @@ PRIVATE_KEY=your_wallet_private_key_here
 
 # Uniswap
 UNISWAP_POSITION_MANAGER_ADDRESS=0xC36442b4a4522E871399CD717aBDD847Ab11FE88  # Mainnet NFT Position Manager
+UNISWAP_POSITION_ID=1016832
+UNISWAP_POSITION_CREATION_DATE=2025-06-25
+
+# Aerodrome
+AERODROME_POOL_ADDRESS=0x3e66e55e97ce60096f74b7C475e8249f2D31a9fb  # cbBTC/USDC on Base
+AERODROME_GAUGE_ADDRESS=  # Optional: specific gauge address if needed
 
 #Hyperliquid
 HL_KEY=your_hyperliquid_api_key #https://app.hyperliquid.xyz/API

--- a/src/aerodrome/aerodrome.service.ts
+++ b/src/aerodrome/aerodrome.service.ts
@@ -78,6 +78,7 @@ export class AerodromeLpService {
         poolAddress,
         this.config.contracts.positionManager,
         this.provider,
+        this.configService.get('aerodrome').gaugeAddress,
       );
 
       if (!userPosition) {

--- a/src/app.controller.ts
+++ b/src/app.controller.ts
@@ -1,12 +1,55 @@
-import { Controller, Get } from '@nestjs/common';
+import { Controller, Get, Param } from '@nestjs/common';
 import { AppService } from './app.service';
+import { AerodromeLpService } from './aerodrome/aerodrome.service';
 
 @Controller()
 export class AppController {
-  constructor(private readonly appService: AppService) {}
+  constructor(
+    private readonly appService: AppService,
+    private readonly aerodromeService: AerodromeLpService,
+  ) {}
 
-  // @Get()
-  // getHello(): string {
-  //   return this.appService.getHello();
-  // }
+  @Get()
+  getRoot() {
+    return {
+      message: 'Portfolio Manager API',
+      version: '1.0.0',
+      endpoints: [
+        'GET /aerodrome/status - Get overview of all Aerodrome positions',
+        'GET /aerodrome/positions - Get all positions',
+        'GET /aerodrome/position/:poolAddress - Get specific position'
+      ]
+    };
+  }
+
+  @Get('aerodrome/positions')
+  async getAerodromePositions() {
+    const signerAddress = await this.aerodromeService.getSignerAddress();
+    return this.aerodromeService.getPositionsByOwner(signerAddress);
+  }
+
+  @Get('aerodrome/position/:poolAddress')
+  async getAerodromePosition(@Param('poolAddress') poolAddress: string) {
+    const signerAddress = await this.aerodromeService.getSignerAddress();
+    return this.aerodromeService.getPosition(signerAddress, poolAddress);
+  }
+
+  @Get('aerodrome/status')
+  async getAerodromeStatus() {
+    const signerAddress = await this.aerodromeService.getSignerAddress();
+    const positions = await this.aerodromeService.getPositionsByOwner(signerAddress);
+    
+    return {
+      walletAddress: signerAddress,
+      totalPositions: positions.length,
+      positions: positions.map(pos => ({
+        tokenId: pos.tokenId,
+        pool: pos.poolAddress,
+        pair: `${pos.token0Symbol}/${pos.token1Symbol}`,
+        liquidity: `${pos.token0Balance} ${pos.token0Symbol} + ${pos.token1Balance} ${pos.token1Symbol}`,
+        isStaked: pos.isStaked,
+        pendingRewards: pos.pendingAeroRewards
+      }))
+    };
+  }
 }

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -3,6 +3,7 @@ import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { HyperliquidService } from './hyperliquid/hyperliquid.service';
 import { UniswapLpService } from './uniswap-lp/uniswap-lp.service';
+import { AerodromeLpService } from './aerodrome/aerodrome.service';
 import { AppConfigModule } from './config/config.module';
 import { FundingService } from './funding/funding.service';
 import { BinanceService } from './binance/binance.service';
@@ -14,6 +15,7 @@ import { BinanceService } from './binance/binance.service';
     AppService,
     HyperliquidService,
     UniswapLpService,
+    AerodromeLpService,
     FundingService,
     BinanceService,
   ],

--- a/src/config/configuration.ts
+++ b/src/config/configuration.ts
@@ -13,9 +13,14 @@ export interface BaseConfig {
 export interface Config {
   port: number;
   walletAddress: string;
+  lpProvider: 'uniswap' | 'aerodrome';
   uniswap: {
     positionId: string;
     positionCreationDate: string;
+  };
+  aerodrome: {
+    poolAddress: string;
+    gaugeAddress: string;
   };
   ethereum: {
     rpcUrl: string;
@@ -40,9 +45,14 @@ export interface Config {
 export default (): Config => ({
   port: parseInt(process.env.PORT || '3000', 10),
   walletAddress: process.env.WALLET_ADDRESS || '',
+  lpProvider: (process.env.LP_PROVIDER as 'uniswap' | 'aerodrome') || 'uniswap',
   uniswap: {
     positionId: process.env.UNISWAP_POSITION_ID || '1016832',
     positionCreationDate: process.env.UNISWAP_POSITION_CREATION_DATE || '2025-06-25',
+  },
+  aerodrome: {
+    poolAddress: process.env.AERODROME_POOL_ADDRESS || '',
+    gaugeAddress: process.env.AERODROME_GAUGE_ADDRESS || '',
   },
   ethereum: {
     rpcUrl: process.env.ETH_RPC_URL || '',
@@ -65,7 +75,12 @@ export default (): Config => ({
     contracts: {
       factory: '0x5e7BB104d84c7CB9B682AaC2F3d509f5F406809A',
       positionManager: '0x827922686190790b37229fd06084350E74485b72',
-      pools: ['0x3e66e55e97ce60096f74b7C475e8249f2D31a9fb'], // 0: default
+      pools: [
+        process.env.AERODROME_POOL_ADDRESS, // User's specific pool from env
+        '0x3e66e55e97ce60096f74b7C475e8249f2D31a9fb', // cbBTC/USDC (volatile)
+        '0x1F40e42E92Cd3dDEC8Ac7d950A4E15378a0A7d8e', // WETH/USDC (volatile) 
+        '0x0b1A513ee24972DAEf112bC777a5610d4325C9e7', // cbBTC/WBTC (stable)
+      ].filter(Boolean).filter((pool, index, arr) => arr.indexOf(pool) === index), // Remove duplicates and empty values
     },
   },
   hyperliquid: {

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,8 +2,11 @@ import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
 import { HyperliquidService } from './hyperliquid/hyperliquid.service';
 import { UniswapLpService } from './uniswap-lp/uniswap-lp.service';
+import { AerodromeLpService } from './aerodrome/aerodrome.service';
 import { Logger } from '@nestjs/common';
 import { AppService } from './app.service';
+import { ConfigService } from '@nestjs/config';
+import { Config } from './config/configuration';
 
 async function bootstrap() {
   const logger = new Logger('Bootstrap');
@@ -12,19 +15,32 @@ async function bootstrap() {
   // Enable CORS if needed
   app.enableCors();
   
-  // Initialize services
+  // Initialize services based on configuration
+  const configService = app.get(ConfigService<Config>);
   const hyperliquidService = app.get(HyperliquidService);
-  const uniswapLpService = app.get(UniswapLpService);
   const appService = app.get(AppService);
-
-  logger.log('Initializing services...');
+  
+  const lpProvider = configService.get('lpProvider');
+  logger.log(`Initializing services with LP provider: ${lpProvider}...`);
   
   try {
-    await Promise.all([
+    const initPromises = [
       hyperliquidService.bootstrap(),
-      uniswapLpService.bootstrap(),
       appService.bootstrap(),
-    ]);
+    ];
+    
+    // Only initialize the LP service we're actually using
+    if (lpProvider === 'aerodrome') {
+      logger.log('Using Aerodrome LP provider');
+      const aerodromeService = app.get(AerodromeLpService);
+      initPromises.push(aerodromeService.bootstrap());
+    } else {
+      logger.log('Using Uniswap LP provider');
+      const uniswapLpService = app.get(UniswapLpService);
+      initPromises.push(uniswapLpService.bootstrap());
+    }
+    
+    await Promise.all(initPromises);
     
     const port = process.env.PORT || 3000;
     await app.listen(port);


### PR DESCRIPTION
This commit introduces support for Aerodrome as an alternative LP provider while maintaining full compatibility with existing Uniswap V3 functionality.

Configuration Changes:
- Added LP_PROVIDER env variable to switch between 'uniswap' and 'aerodrome'
- Added AERODROME_POOL_ADDRESS and AERODROME_GAUGE_ADDRESS env variables
- Updated configuration.ts with lpProvider field and aerodrome config section
- Extended Base chain config with multiple Aerodrome pool addresses

Core Implementation:
- Added LP provider abstraction layer in app.service.ts
  - getLpPosition() method handles both Uniswap and Aerodrome positions
  - getPoolPriceHistory() method for unified price data access
  - Automatic provider selection based on LP_PROVIDER config
- Updated aerodrome contract.client.ts to support optional gauge address fallback
- Modified getUserStakedPosition to accept optional knownGaugeAddress parameter

Service Integration:
- Updated main.ts to conditionally initialize only the selected LP service
- Modified bootstrap process to initialize Aerodrome when selected
- Added AerodromeLpService to app.module.ts providers

REST API Endpoints:
- GET /aerodrome/positions - List all Aerodrome positions
- GET /aerodrome/position/:poolAddress - Get specific position details
- GET /aerodrome/status - Overview of all positions with rewards

Technical Details:
- Aerodrome positions return formatted token balances that are parsed back to raw values
- Gauge address fallback mechanism for pools without standard gauge() function
- Maintains same position monitoring and hedging logic for both providers